### PR TITLE
Use default Go string conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ package main
 import "github.com/sundowndev/dorkgen"
 
 func main() {
-  dork := &dorkgen.GoogleSearch{}
-  // dork := &dorkgen.DuckDuckGo{}
-  // dork := &dorkgen.Bing{}
+  dork := dorkgen.NewGoogleSearch()
+  // dork := dorkgen.NewDuckDuckGo()
+  // dork := dorkgen.NewBing()
 
-  dork.Site("example.com").Intext("text").ToString()
+  dork.Site("example.com").Intext("text").String()
   // returns: site:example.com intext:"text"
 }
 ```
@@ -56,10 +56,10 @@ func main() {
 
 ```go
 func main() {
-  dork.Site("facebook.com").Or().Site("twitter.com").ToString()
+  dork.Site("facebook.com").Or().Site("twitter.com").String()
   // returns: site:facebook.com OR site:twitter.com
 
-  dork.Intext("facebook").And().Intext("twitter").ToString()
+  dork.Intext("facebook").And().Intext("twitter").String()
   // returns: intext:"facebook" AND intext:"twitter"
 }
 ```
@@ -69,9 +69,9 @@ func main() {
 ```go
 func main() {
   dork.
-    Exclude((&dorkgen.GoogleSearch{}).
+    Exclude((dorkgen.NewGoogleSearch()).
       Site("example.com").
-      ToString()).
+      String()).
     Site("example.*").
     Or().
     Intext("text")
@@ -84,13 +84,12 @@ func main() {
 ```go
 func main() {
   dork.
-    Group((&dorkgen.GoogleSearch{}).
+    Group((dorkgen.NewGoogleSearch()).
       Site("facebook.com").
       Or().
-      Site("twitter.com").
-      ToString()).
+      Site("twitter.com")).
     Intext("wtf").
-    ToString()
+    String()
   // returns: (site:facebook.com OR site:twitter.com) "wtf"
 }
 ```
@@ -101,11 +100,11 @@ func main() {
 func main() {
   dork.
     Site("facebook.*").
-    Exclude((&dorkgen.GoogleSearch{}).
+    Exclude((dorkgen.NewGoogleSearch()).
       Site("facebook.com").
-      ToString())
+      String())
 
-  dork.ToString()
+  dork.String()
   // returns: site:facebook.* -site:facebook.com
   dork.ToURL()
   // returns: https://www.google.com/search?q=site%3Afacebook.%2A+-site%3Afacebook.com

--- a/doc.go
+++ b/doc.go
@@ -8,12 +8,28 @@ package main
 import "github.com/sundowndev/dorkgen"
 
 func main() {
-	dork := &dorkgen.GoogleSearch{}
-	// dork := &dorkgen.DuckDuckGo{}
-	// dork := &dorkgen.Bing{}
+	dork := dorkgen.NewGoogleSearch()
+	// dork := dorkgen.NewDuckDuckGo()
+	// dork := dorkgen.NewBing()
 
-	dork.Site("example.com").Intext("text").ToString()
+	dork.Site("example.com").Intext("text").String()
 	// returns: site:example.com "text"
+}
+
+// You can also isolate tags between parentheses
+func main() {
+	dork := dorkgen.NewGoogleSearch()
+
+	dork.Group(
+		dorkgen.NewGoogleSearch().
+			Site("facebook.com")).
+	Or().
+	Group(
+		dorkgen.NewGoogleSearch().
+			Site("twitter.com")).
+	Intext("text")
+	String()
+	// returns: (site:facebook.com) OR (site:twitter.com) "text"
 }
 */
 package dorkgen

--- a/go.sum
+++ b/go.sum
@@ -3,11 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/google.go
+++ b/google.go
@@ -23,8 +23,8 @@ type GoogleSearch struct {
 	EngineFactory
 }
 
-// ToString converts all tags to a single request
-func (e *GoogleSearch) ToString() string {
+// String converts all tags to a single request
+func (e *GoogleSearch) String() string {
 	return strings.Join(e.tags, " ")
 }
 
@@ -96,9 +96,9 @@ func (e *GoogleSearch) Exclude(value string) *GoogleSearch {
 	return e
 }
 
-// Group isolate tags between parentheses.
-func (e *GoogleSearch) Group(value string) *GoogleSearch {
-	e.tags = append(e.tags, "("+value+")")
+// Group isolate tags between parentheses
+func (e *GoogleSearch) Group(tags *GoogleSearch) *GoogleSearch {
+	e.tags = append(e.tags, "("+tags.String()+")")
 	return e
 }
 

--- a/google.go
+++ b/google.go
@@ -23,6 +23,10 @@ type GoogleSearch struct {
 	EngineFactory
 }
 
+func NewGoogleSearch() *GoogleSearch {
+	return &GoogleSearch{}
+}
+
 // String converts all tags to a single request
 func (e *GoogleSearch) String() string {
 	return strings.Join(e.tags, " ")

--- a/google_test.go
+++ b/google_test.go
@@ -1,15 +1,16 @@
 package dorkgen
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assertion "github.com/stretchr/testify/assert"
 )
 
 var dork *GoogleSearch
 
 func TestInit(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertion.New(t)
 
 	t.Run("should convert to URL correctly", func(t *testing.T) {
 		dork = &GoogleSearch{}
@@ -21,12 +22,20 @@ func TestInit(t *testing.T) {
 		assert.Equal(result, "https://www.google.com/search?q=site%3Aexample.com", "they should be equal")
 	})
 
+	t.Run("should convert to string correctly", func(t *testing.T) {
+		dork = &GoogleSearch{}
+
+		result := fmt.Sprint(dork.Site("example.com"))
+
+		assert.Equal(result, "site:example.com", "they should be equal")
+	})
+
 	t.Run("should handle site tag correctly", func(t *testing.T) {
 		dork = &GoogleSearch{}
 
 		result := dork.
 			Site("example.com").
-			ToString()
+			String()
 
 		assert.Equal(result, "site:example.com", "they should be equal")
 	})
@@ -36,7 +45,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Intext("text").
-			ToString()
+			String()
 
 		assert.Equal(result, "intext:\"text\"", "they should be equal")
 	})
@@ -46,7 +55,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Inurl("index.php").
-			ToString()
+			String()
 
 		assert.Equal(result, "inurl:\"index.php\"", "they should be equal")
 	})
@@ -56,7 +65,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Filetype("pdf").
-			ToString()
+			String()
 
 		assert.Equal(result, "filetype:\"pdf\"", "they should be equal")
 	})
@@ -66,7 +75,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Cache("www.google.com").
-			ToString()
+			String()
 
 		assert.Equal(result, "cache:\"www.google.com\"", "they should be equal")
 	})
@@ -76,7 +85,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Related("www.google.com").
-			ToString()
+			String()
 
 		assert.Equal(result, "related:\"www.google.com\"", "they should be equal")
 	})
@@ -86,7 +95,7 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Ext("(doc | pdf | xls | txt | xml)").
-			ToString()
+			String()
 
 		assert.Equal(result, "ext:(doc | pdf | xls | txt | xml)", "they should be equal")
 	})
@@ -99,7 +108,7 @@ func TestInit(t *testing.T) {
 			Exclude("htm").
 			Exclude("php").
 			Exclude("md5sums").
-			ToString()
+			String()
 
 		assert.Equal(result, "-html -htm -php -md5sums", "they should be equal")
 	})
@@ -111,7 +120,7 @@ func TestInit(t *testing.T) {
 			Site("facebook.com").
 			Or().
 			Site("twitter.com").
-			ToString()
+			String()
 
 		assert.Equal(result, "site:facebook.com OR site:twitter.com", "they should be equal")
 	})
@@ -121,8 +130,8 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Site("linkedin.com").
-			Group((&GoogleSearch{}).Intext("1").Or().Intext("2").ToString()).
-			ToString()
+			Group((&GoogleSearch{}).Intext("1").Or().Intext("2")).
+			String()
 
 		assert.Equal(result, "site:linkedin.com (intext:\"1\" OR intext:\"2\")", "they should be equal")
 	})
@@ -132,9 +141,9 @@ func TestInit(t *testing.T) {
 
 		result := dork.
 			Site("linkedin.com").
-			Group((&GoogleSearch{}).Intext("1").Or().Intext("2").ToString()).
+			Group((&GoogleSearch{}).Intext("1").Or().Intext("2")).
 			Intitle("jordan").
-			ToString()
+			String()
 
 		assert.Equal(result, "site:linkedin.com (intext:\"1\" OR intext:\"2\") intitle:\"jordan\"", "they should be equal")
 	})

--- a/google_test.go
+++ b/google_test.go
@@ -13,7 +13,7 @@ func TestInit(t *testing.T) {
 	assert := assertion.New(t)
 
 	t.Run("should convert to URL correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Site("example.com").
@@ -23,7 +23,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should convert to string correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := fmt.Sprint(dork.Site("example.com"))
 
@@ -31,7 +31,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle site tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Site("example.com").
@@ -41,7 +41,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle intext tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Intext("text").
@@ -51,7 +51,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle inurl tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Inurl("index.php").
@@ -61,7 +61,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle filetype tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Filetype("pdf").
@@ -71,7 +71,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle cache tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Cache("www.google.com").
@@ -81,7 +81,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle related tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Related("www.google.com").
@@ -91,7 +91,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle ext tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Ext("(doc | pdf | xls | txt | xml)").
@@ -101,7 +101,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle exclude tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Exclude("html").
@@ -114,7 +114,7 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle or tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Site("facebook.com").
@@ -126,22 +126,22 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("should handle group tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Site("linkedin.com").
-			Group((&GoogleSearch{}).Intext("1").Or().Intext("2")).
+			Group((NewGoogleSearch()).Intext("1").Or().Intext("2")).
 			String()
 
 		assert.Equal(result, "site:linkedin.com (intext:\"1\" OR intext:\"2\")", "they should be equal")
 	})
 
 	t.Run("should handle group tag correctly", func(t *testing.T) {
-		dork = &GoogleSearch{}
+		dork = NewGoogleSearch()
 
 		result := dork.
 			Site("linkedin.com").
-			Group((&GoogleSearch{}).Intext("1").Or().Intext("2")).
+			Group((NewGoogleSearch()).Intext("1").Or().Intext("2")).
 			Intitle("jordan").
 			String()
 


### PR DESCRIPTION
- Rename .ToString() to .String()
- Create NewGoogleSearch() method
- run go mod tidy
- Update documentation
- Update .Group() interface to receive a GoogleSearch struct pointer